### PR TITLE
Fix typos in ia3.py

### DIFF
--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -48,12 +48,9 @@ class IA3Config(PeftConfig):
 
     Args:
         target_modules (`Union[List[str],str]`): The names of the modules to apply (IA)^3 to.
-        feedforward_modules (`Union[List[str],str]`): The names of the modules to be treated as feedforward modules
-        as in the original paper.
-        fan_in_fan_out (`bool`): Set this to True if the layer to replace stores weight like (fan_in, fan_out).
-        For example, gpt-2 uses `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`.:
-        modules_to_save (`List[str]`):List of modules apart from (IA)^3 layers to be set as trainable
-            and saved in the final checkpoint.
+        feedforward_modules (`Union[List[str],str]`): The names of the modules to be treated as feedforward modules, as in the original paper.
+        fan_in_fan_out (`bool`): Set this to True if the layer to replace stores weight like (fan_in, fan_out). For example, gpt-2 uses `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`.
+        modules_to_save (`List[str]`): List of modules apart from (IA)^3 layers to be set as trainable and saved in the final checkpoint.
         init_ia3_weights (`bool`): Whether to initialize the vectors in the (IA)^3 layers, defaults to `True`.
     """
 


### PR DESCRIPTION
I noticed they led to weird formatting on the HF documentation here: https://huggingface.co/docs/peft/main/en/package_reference/tuners#peft.IA3Config